### PR TITLE
Add ignores for 1.3.0

### DIFF
--- a/versions/scylla/v1.3.0/ignore.yaml
+++ b/versions/scylla/v1.3.0/ignore.yaml
@@ -1,0 +1,4 @@
+tests:
+    ignore:
+        # https://github.com/scylladb/scylla-rust-driver-matrix/issues/26
+        - "load_balancing::tablets::test_default_policy_is_tablet_aware"


### PR DESCRIPTION
One of the 2 tests ignored in 1.2.0 was fixed, the other unfortunately not yet.