### PR TITLE
1.4.1: Ignore failing test

### DIFF
--- a/versions/scylla/v1.4.1/ignore.yaml
+++ b/versions/scylla/v1.4.1/ignore.yaml
@@ -1,0 +1,3 @@
+tests:
+    ignore:
+        - "load_balancing::tablets::test_default_policy_is_tablet_aware"


### PR DESCRIPTION
I thought it works, but it failed for 2025.1 https://jenkins.scylladb.com/job/scylla-2025.1/job/driver-tests/job/rust-driver-matrix-test/32/testReport/