### PR TITLE
Add GitHub Actions integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,270 @@
+name: Integration Tests
+
+on:
+  workflow_call:
+    inputs:
+      driver_repository:
+        description: Driver repository to test, for example scylladb/scylla-rust-driver.
+        required: true
+        type: string
+      driver_type:
+        description: Driver family used by the matrix code.
+        required: true
+        type: string
+      driver_ref:
+        description: Driver git ref to test. When empty, the latest tag from the driver repository is used.
+        required: false
+        type: string
+        default: ""
+      scylla_version:
+        description: Scylla version or alias to test. Supported aliases are LATEST, PRIOR, LTS-LATEST, and LTS-PRIOR. When empty, LATEST is used.
+        required: false
+        type: string
+        default: ""
+      tests:
+        description: Optional test selector passed through to the runner.
+        required: false
+        type: string
+        default: "rust"
+      test_threads:
+        description: Cargo/nextest test thread count passed through to the runner.
+        required: false
+        type: string
+        default: "1"
+
+permissions:
+  contents: read
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+    env:
+      WORKSPACE: ${{ github.workspace }}
+      CCM_DIR: ${{ github.workspace }}/scylla-ccm
+      RUST_MATRIX_DIR: ${{ github.workspace }}
+      RUST_DRIVER_DIR: ${{ github.workspace }}/driver
+    steps:
+      - name: Checkout matrix
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Select Scylla version query
+        id: scylla-query
+        env:
+          SCYLLA_VERSION: ${{ inputs.scylla_version }}
+        run: |
+          set -euo pipefail
+
+          target="${SCYLLA_VERSION:-LATEST}"
+          filters=""
+          fallback_repo=""
+          fallback_filters=""
+          needs_resolution=true
+
+          case "$target" in
+            LTS-LATEST)
+              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.1.LAST'
+              ;;
+            LTS-PRIOR)
+              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST-1.1.LAST'
+              fallback_repo="scylladb/scylla-enterprise"
+              fallback_filters="$filters"
+              ;;
+            LATEST)
+              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST'
+              ;;
+            PRIOR)
+              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST-1'
+              fallback_filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST-1.LAST'
+              ;;
+            *)
+              needs_resolution=false
+              ;;
+          esac
+
+          {
+            echo "target=$target"
+            echo "needs_resolution=$needs_resolution"
+            echo "repo=scylladb/scylla"
+            echo "fallback_repo=$fallback_repo"
+            echo "filters=$filters"
+            echo "fallback_filters=$fallback_filters"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve Scylla version
+        if: ${{ steps.scylla-query.outputs.needs_resolution == 'true' }}
+        id: get-scylla-version
+        uses: scylladb-actions/get-version@a1dc4fedfb5684242148020b24e4150b1fe7ad08 # v0.4.5
+        with:
+          source: dockerhub-imagetag
+          repo: ${{ steps.scylla-query.outputs.repo }}
+          filters: ${{ steps.scylla-query.outputs.filters }}
+          github-token: ${{ github.token }}
+
+      - name: Resolve Scylla version fallback
+        if: ${{ steps.scylla-query.outputs.fallback_filters != '' && (steps.get-scylla-version.outputs.versions == '' || steps.get-scylla-version.outputs.versions == '[]') }}
+        id: get-scylla-version-fallback
+        uses: scylladb-actions/get-version@a1dc4fedfb5684242148020b24e4150b1fe7ad08 # v0.4.5
+        with:
+          source: dockerhub-imagetag
+          repo: ${{ steps.scylla-query.outputs.fallback_repo || steps.scylla-query.outputs.repo }}
+          filters: ${{ steps.scylla-query.outputs.fallback_filters }}
+          github-token: ${{ github.token }}
+
+      - name: Normalize inputs
+        id: resolve
+        env:
+          DRIVER_REF_INPUT: ${{ inputs.driver_ref }}
+          DRIVER_TYPE: ${{ inputs.driver_type }}
+          SCYLLA_VERSION_TARGET: ${{ steps.scylla-query.outputs.target }}
+          SCYLLA_VERSION_NEEDS_RESOLUTION: ${{ steps.scylla-query.outputs.needs_resolution }}
+          SCYLLA_VERSION_RESOLVED: ${{ steps.get-scylla-version.outputs.versions }}
+          SCYLLA_VERSION_FALLBACK: ${{ steps.get-scylla-version-fallback.outputs.versions }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+
+          def first_version(versions_json: str) -> str:
+              if not versions_json:
+                  return ""
+              versions = json.loads(versions_json)
+              if isinstance(versions, str):
+                  return versions
+              if isinstance(versions, list):
+                  return versions[0] if versions else ""
+              raise SystemExit(f"Unexpected get-version output: {versions!r}")
+
+          def ccm_version(version: str) -> str:
+              if re.fullmatch(r"\d+(?:\.\d+)+", version):
+                  return f"release:{version}"
+              return version
+
+          driver_ref = os.environ["DRIVER_REF_INPUT"]
+          scylla_target = os.environ["SCYLLA_VERSION_TARGET"]
+          if os.environ["SCYLLA_VERSION_NEEDS_RESOLUTION"] == "true":
+              scylla_version = first_version(os.environ.get("SCYLLA_VERSION_RESOLVED", ""))
+              scylla_version = scylla_version or first_version(os.environ.get("SCYLLA_VERSION_FALLBACK", ""))
+              if not scylla_version:
+                  raise SystemExit(f"Unable to resolve Scylla version target {scylla_target}")
+          else:
+              scylla_version = scylla_target
+          scylla_version = ccm_version(scylla_version)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"driver_ref={driver_ref}\n")
+              fh.write(f"scylla_version_target={scylla_target}\n")
+              fh.write(f"scylla_version={scylla_version}\n")
+              artifact_ref = driver_ref or "latest"
+              artifact_suffix = re.sub(r"[^A-Za-z0-9_.-]+", "-", f"{os.environ['DRIVER_TYPE']}-{artifact_ref}-{scylla_version}")
+              fh.write(f"artifact_suffix={artifact_suffix}\n")
+          PY
+
+      - name: Restore CCM download cache
+        id: ccm-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.ccm/scylla-repository
+          key: ccm-${{ runner.os }}-${{ steps.resolve.outputs.scylla_version }}
+
+      - name: Checkout driver repository
+        if: ${{ steps.resolve.outputs.driver_ref != '' }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ inputs.driver_repository }}
+          ref: ${{ steps.resolve.outputs.driver_ref }}
+          path: driver
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout default driver repository
+        if: ${{ steps.resolve.outputs.driver_ref == '' }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ inputs.driver_repository }}
+          path: driver
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout CCM repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: scylladb/scylla-ccm
+          path: scylla-ccm
+          persist-credentials: false
+
+      - name: Run integration tests
+        env:
+          DRIVER_REF: ${{ steps.resolve.outputs.driver_ref }}
+          SCYLLA_VERSION: ${{ steps.resolve.outputs.scylla_version }}
+          TESTS: ${{ inputs.tests }}
+          TEST_THREADS: ${{ inputs.test_threads }}
+        run: |
+          set -euo pipefail
+          args=(./scripts/run_test.sh python3 ./main.py "$RUST_DRIVER_DIR" --tests "$TESTS" --scylla-version "$SCYLLA_VERSION")
+          if [ -n "$DRIVER_REF" ]; then
+            args+=(--versions "$DRIVER_REF")
+          else
+            args+=(--rust-driver-versions-size 1)
+          fi
+          if [ -n "$TEST_THREADS" ]; then
+            args+=(--test-threads "$TEST_THREADS")
+          fi
+          "${args[@]}"
+
+      - name: Upload integration test reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: integration-reports-${{ steps.resolve.outputs.artifact_suffix }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            test_results/
+            argus_test_results/
+            driver/target/nextest/**
+            driver/ccm/**/logs/**
+
+      - name: Upload CCM logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ccm-logs-${{ steps.resolve.outputs.artifact_suffix }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: |
+            ~/.ccm/*/node*/logs/**
+            ~/.ccm/*/*.log
+            driver/ccm/**/logs/**
+
+      - name: Inspect CCM download cache
+        id: ccm-snapshot
+        if: ${{ steps.ccm-cache.outputs.cache-hit != 'true' }}
+        run: |
+          set -euo pipefail
+
+          host_dir="$HOME/.ccm/scylla-repository"
+
+          if [ -d "$host_dir" ] && find "$host_dir" -mindepth 1 -type f -print -quit | grep -q .; then
+            file_count=$(find "$host_dir" -type f | wc -l | tr -d ' ')
+            echo "CCM cache available at $host_dir ($file_count files)"
+            echo "snapshot=true" >> "$GITHUB_OUTPUT"
+            echo "files=$file_count" >> "$GITHUB_OUTPUT"
+            du -sh "$host_dir" || true
+            exit 0
+          fi
+
+          echo "CCM cache contents were not available for snapshot"
+          echo "snapshot=false" >> "$GITHUB_OUTPUT"
+
+      - name: Save CCM download cache
+        if: ${{ steps.ccm-cache.outputs.cache-hit != 'true' && steps.ccm-snapshot.outputs.snapshot == 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.ccm/scylla-repository
+          key: ccm-${{ runner.os }}-${{ steps.resolve.outputs.scylla_version }}

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,0 +1,129 @@
+name: PR Integration Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changes:
+    name: Detect PR changes
+    runs-on: ubuntu-latest
+    outputs:
+      runner_changed: ${{ steps.detect.outputs.runner_changed }}
+      scripts_image_source_changed: ${{ steps.detect.outputs.scripts_image_source_changed }}
+      scripts_image_changed: ${{ steps.detect.outputs.scripts_image_changed }}
+      version_count: ${{ steps.detect.outputs.version_count }}
+      version_matrix: ${{ steps.detect.outputs.version_matrix }}
+    steps:
+      - name: Checkout matrix
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Detect changed paths
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+          from urllib.request import Request, urlopen
+
+          sys.path.insert(0, os.environ["GITHUB_WORKSPACE"])
+          from scripts.pr_integration_changes import detect_changes
+
+          api_url = os.environ["GITHUB_API_URL"].rstrip("/")
+          repo = os.environ["GITHUB_REPOSITORY"]
+          pr_number = os.environ["PR_NUMBER"]
+          token = os.environ["GH_TOKEN"]
+
+          changed_files = []
+          page = 1
+          while True:
+              request = Request(
+                  f"{api_url}/repos/{repo}/pulls/{pr_number}/files?per_page=100&page={page}",
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urlopen(request) as response:
+                  batch = json.load(response)
+              if not batch:
+                  break
+              changed_files.extend(item["filename"] for item in batch)
+              if len(batch) < 100:
+                  break
+              page += 1
+
+          outputs = detect_changes(changed_files, repo_root=Path("."))
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              for name, value in outputs.items():
+                  output.write(f"{name}={value}\n")
+          PY
+
+  require-scripts-image:
+    name: Require scripts/image update
+    needs: changes
+    if: ${{ needs.changes.outputs.scripts_image_source_changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check scripts/image changed
+        env:
+          SCRIPTS_IMAGE_CHANGED: ${{ needs.changes.outputs.scripts_image_changed }}
+        run: |
+          set -euo pipefail
+          if [ "$SCRIPTS_IMAGE_CHANGED" != "true" ]; then
+            echo "::error::Changes to Docker image inputs require scripts/image to be updated in the same PR."
+            exit 1
+          fi
+          echo "scripts/image was updated."
+
+  current-workflow:
+    needs: changes
+    if: ${{ needs.changes.outputs.runner_changed == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - driver_type: scylla
+            driver_repository: scylladb/scylla-rust-driver
+            scylla_version: LATEST
+          - driver_type: scylla
+            driver_repository: scylladb/scylla-rust-driver
+            scylla_version: PRIOR
+          - driver_type: scylla
+            driver_repository: scylladb/scylla-rust-driver
+            scylla_version: LTS-LATEST
+          - driver_type: scylla
+            driver_repository: scylladb/scylla-rust-driver
+            scylla_version: LTS-PRIOR
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      driver_repository: ${{ matrix.driver_repository }}
+      driver_type: ${{ matrix.driver_type }}
+      scylla_version: ${{ matrix.scylla_version }}
+
+  changed-driver-version-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.version_count != '0' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.changes.outputs.version_matrix) }}
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      driver_repository: ${{ matrix.driver_repository }}
+      driver_type: ${{ matrix.driver_type }}
+      driver_ref: ${{ matrix.driver_ref }}
+      scylla_version: LATEST

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ requires-python = ">=3.13"
 
 [dependency-groups]
 dev = [
+    "pytest",
     "pyright",
     "ruff"
 ]

--- a/scripts/pr_integration_changes.py
+++ b/scripts/pr_integration_changes.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+
+REPOSITORIES = {
+    "scylla": "scylladb/scylla-rust-driver",
+}
+
+IMAGE_SOURCE_PATHS = {"scripts/Dockerfile", "scripts/entrypoint.sh"}
+
+RUNNER_PATHS = {
+    ".github/workflows/integration-tests.yml",
+    ".github/workflows/pr-integration-tests.yml",
+    "pyproject.toml",
+    "scripts/run_test.sh",
+    "scripts/image",
+    *IMAGE_SOURCE_PATHS,
+}
+
+
+def is_runner_path(filename: str) -> bool:
+    return filename.endswith(".py") or filename in RUNNER_PATHS
+
+
+def driver_ref_for_version(version: str) -> str:
+    if version == "master" or version.startswith("v"):
+        return version
+    return f"v{version}"
+
+
+def detect_changes(changed_files: Iterable[str], repo_root: Path = Path(".")) -> dict[str, str]:
+    repo_root = Path(repo_root)
+    changed_files = list(changed_files)
+
+    version_dirs = set()
+    for filename in changed_files:
+        parts = filename.split("/")
+        if len(parts) >= 3 and parts[0] == "versions":
+            path = repo_root / parts[0] / parts[1] / parts[2]
+            if path.is_dir():
+                version_dirs.add((parts[1], parts[2]))
+
+    version_matrix = []
+    for driver_type, version in sorted(version_dirs):
+        repository = REPOSITORIES.get(driver_type)
+        if repository is None:
+            raise SystemExit(f"Unsupported driver type in versions/{driver_type}/{version}")
+        version_matrix.append(
+            {
+                "driver_type": driver_type,
+                "driver_repository": repository,
+                "driver_version": version,
+                "driver_ref": driver_ref_for_version(version),
+            }
+        )
+
+    runner_changed = any(is_runner_path(filename) for filename in changed_files)
+    scripts_image_source_changed = any(filename in IMAGE_SOURCE_PATHS for filename in changed_files)
+    scripts_image_changed = "scripts/image" in changed_files and (repo_root / "scripts/image").is_file()
+
+    matrix = {
+        "include": version_matrix
+        or [
+            {
+                "driver_type": "none",
+                "driver_repository": "none",
+                "driver_version": "none",
+                "driver_ref": "none",
+            }
+        ]
+    }
+
+    return {
+        "runner_changed": str(runner_changed).lower(),
+        "scripts_image_source_changed": str(scripts_image_source_changed).lower(),
+        "scripts_image_changed": str(scripts_image_changed).lower(),
+        "version_count": str(len(version_matrix)),
+        "version_matrix": json.dumps(matrix, separators=(",", ":")),
+    }

--- a/tests/test_pr_integration_changes.py
+++ b/tests/test_pr_integration_changes.py
@@ -1,0 +1,75 @@
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.pr_integration_changes import detect_changes
+
+
+def test_runner_changes_include_shell_wrapper_entrypoint_pyproject_and_workflows():
+    for changed_file in [
+        "scripts/run_test.sh",
+        "scripts/entrypoint.sh",
+        "scripts/image",
+        "pyproject.toml",
+        ".github/workflows/integration-tests.yml",
+        ".github/workflows/pr-integration-tests.yml",
+        "main.py",
+    ]:
+        outputs = detect_changes([changed_file], repo_root=REPO_ROOT)
+
+        assert outputs["runner_changed"] == "true", changed_file
+
+
+def test_changed_scylla_version_expands_to_driver_matrix_entry():
+    outputs = detect_changes(["versions/scylla/v1.7.0/ignore.yaml"], repo_root=REPO_ROOT)
+
+    assert outputs["version_count"] == "1"
+    matrix = json.loads(outputs["version_matrix"])
+    assert matrix["include"] == [
+        {
+            "driver_type": "scylla",
+            "driver_repository": "scylladb/scylla-rust-driver",
+            "driver_version": "v1.7.0",
+            "driver_ref": "v1.7.0",
+        }
+    ]
+
+
+def test_image_source_changes_require_scripts_image_update():
+    outputs = detect_changes(["scripts/entrypoint.sh"], repo_root=REPO_ROOT)
+
+    assert outputs["scripts_image_source_changed"] == "true"
+    assert outputs["scripts_image_changed"] == "false"
+
+
+def test_ccm_cache_restore_and_save_use_the_same_path():
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/integration-tests.yml").read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["integration-test"]["steps"]
+    restore = next(step for step in steps if step.get("id") == "ccm-cache")
+    save = next(step for step in steps if step.get("name") == "Save CCM download cache")
+
+    assert restore["with"]["path"] == "~/.ccm/scylla-repository"
+    assert save["with"]["path"] == restore["with"]["path"]
+
+
+def test_integration_workflow_uploads_reports_after_failures():
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/integration-tests.yml").read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["integration-test"]["steps"]
+    reports = next(step for step in steps if step.get("name") == "Upload integration test reports")
+    ccm_logs = next(step for step in steps if step.get("name") == "Upload CCM logs")
+
+    for step in (reports, ccm_logs):
+        assert step["if"] == "${{ always() }}"
+        assert step["uses"].startswith("actions/upload-artifact@")
+        assert len(step["uses"].removeprefix("actions/upload-artifact@")) == 40
+
+    assert "test_results/" in reports["with"]["path"]
+    assert "argus_test_results/" in reports["with"]["path"]
+    assert "driver/target/nextest/**" in reports["with"]["path"]
+    assert "~/.ccm/*/node*/logs/**" in ccm_logs["with"]["path"]


### PR DESCRIPTION
## Goal

- Add GitHub Actions coverage for Scylla Rust driver integration tests.
- Run the relevant integration matrix for pull requests based on what changed.
- Keep test failures visible instead of hiding them in version ignore lists.

## What was done

- Added a reusable integration test workflow.
- Added a PR workflow that detects changed paths and runs the needed integration tests.
- Added PR change detection logic with tests.
- Set the default integration test parallelism to one nextest test per job to reduce concurrent Scylla nodes.
- Removed the v1.7.0 ignore-list workaround from the PR.